### PR TITLE
Add None as default value for params

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -66,8 +66,6 @@ async def es_from_snapshot(es_client):
 @pytest.fixture
 def make_get_request(session):
     async def inner(method: str, params: dict = None) -> HTTPResponse:
-        if params is None:
-            params = {}
         url = "http://" + SERVICE_URL + API_URL + method
         async with session.get(url, params=params) as response:
             return HTTPResponse(

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -65,7 +65,9 @@ async def es_from_snapshot(es_client):
 
 @pytest.fixture
 def make_get_request(session):
-    async def inner(method: str, params: dict) -> HTTPResponse:
+    async def inner(method: str, params: dict = None) -> HTTPResponse:
+        if params is None:
+            params = {}
         url = "http://" + SERVICE_URL + API_URL + method
         async with session.get(url, params=params) as response:
             return HTTPResponse(


### PR DESCRIPTION
`make_get_request` требует аргумент `params`, но не все ручки требуют параметры запроса.
Добавлено значение по умолчанию, чтобы не требовалось передавать его лишний раз.