### PR TITLE
Инфраструктура для сравнения ответов API с ответами, записанными в файлах.

### DIFF
--- a/docker-compose.tests.yaml
+++ b/docker-compose.tests.yaml
@@ -28,7 +28,7 @@ services:
       sh -c "pip install -r tests/functional/requirements.txt
       && python tests/functional/utils/wait_for_es.py
       && python tests/functional/utils/wait_for_redis.py
-      && pytest ./tests/functional/src"
+      && pytest -rP ./tests/functional/src"
     restart: 'no'
   tests_es:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.12.1

--- a/docker-compose.tests.yaml
+++ b/docker-compose.tests.yaml
@@ -11,10 +11,6 @@ services:
       - ./src:/opt/app/src
     environment:
       DEV: 'true'
-  nginx:
-    extends:
-      file: docker-compose.yaml
-      service: nginx
   tests:
     container_name: async_api_tests
     extends:

--- a/src/api/v1/person.py
+++ b/src/api/v1/person.py
@@ -1,7 +1,7 @@
 from http import HTTPStatus
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from models.film import FilmPreview
 from models.person import Person
@@ -35,4 +35,6 @@ async def person_films(person_id: str,
                        person_service: PersonService = Depends(get_person_service)
                        ) -> List[FilmPreview]:
     films = await person_service.get_films_by_person(person_id)
+    if not films:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="person not found")
     return films

--- a/src/services/person.py
+++ b/src/services/person.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import List, Optional, ClassVar
+from typing import ClassVar, List, Optional
 
 import orjson
 from elasticsearch_dsl import Q, Search
@@ -34,9 +34,10 @@ def create_person_search_query(query: str,
     """
     s = Search()
     start = (page - 1) * page_size
-    q = s.query("match", full_name=query)[start:start + page_size]
-    query = q.to_dict()
-    return query
+    if query:
+        s = s.query("match", full_name=query)
+    s = s[start:start + page_size].to_dict()
+    return s
 
 
 def create_films_by_person_query(person_id):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -117,7 +117,7 @@ async def create_movie_index(es_client, redis_client):
 @pytest.fixture(scope="function")
 async def expected_json_response(request):
     """Load expected response from json file with same filename as function name"""
-    file = os.path.join(settings.expected_response_dir, request.node.name + ".json")
+    file = os.path.join(settings.expected_response_dir, f"{request.node.name}.json")
     async with aiofiles.open(file) as f:
         content = await f.read()
         response = json.loads(content)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,15 +1,15 @@
-import os
 import json
+import os
+from dataclasses import dataclass
 
+import aiofiles
 import aiohttp
 import aioredis
 import pytest
 from elasticsearch import AsyncElasticsearch
-from elasticsearch.helpers import async_bulk
 from elasticsearch.client import SnapshotClient
+from elasticsearch.helpers import async_bulk
 from multidict import CIMultiDictProxy
-from pydantic import BaseModel
-from dataclasses import dataclass
 
 from .settings import TestSettings
 
@@ -112,3 +112,13 @@ async def create_movie_index(es_client, redis_client):
     await create_index(es_client, name, index_body, data)
     yield
     await es_client.indices.delete(index=name, ignore=[400, 404])
+
+
+@pytest.fixture(scope="function")
+async def expected_json_response(request):
+    """Load expected response from json file with same filename as function name"""
+    file = os.path.join(settings.expected_response_dir, request.node.name + ".json")
+    async with aiofiles.open(file) as f:
+        content = await f.read()
+        response = json.loads(content)
+    return response

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles==0.7.0
 backoff==1.10.0
 pytest==6.2.4
 pytest-asyncio==0.15.1

--- a/tests/functional/settings.py
+++ b/tests/functional/settings.py
@@ -14,3 +14,5 @@ class TestSettings(BaseSettings):
 
     api_url: str = Field("/api/v1", env="API_URL")
     service_url: str = Field("127.0.0.1:8000", env="SERVICE_URL")
+
+    expected_response_dir = Field("tests/functional/testdata/expected_response")

--- a/tests/functional/src/test_general.py
+++ b/tests/functional/src/test_general.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "route, body",
+    (
+            ("/person/wrong-id", {"detail": "person not found"}),
+            ("/person/wrong-id/film", {"detail": "person not found"}),
+            ("/film/wrong-id", {"detail": "film not found"}),
+            ("/absolutely_wrong_route", {"detail": "Not Found"}),
+    )
+)
+async def test_404_routes(make_get_request, es_from_snapshot, route, body):
+    response = await make_get_request(route)
+    assert response.status == 404
+    assert response.body == body

--- a/tests/functional/src/test_person.py
+++ b/tests/functional/src/test_person.py
@@ -1,10 +1,15 @@
 import pytest
 
+from functional.settings import TestSettings
+
+settings = TestSettings()
+
 
 @pytest.mark.asyncio
-async def test_search_person(make_get_request, es_from_snapshot):
+async def test_search_person(make_get_request, es_from_snapshot, expected_json_response):
     response = await make_get_request("/person/search/", params={"query": "Lucas"})
     assert response.status == 200
+    assert response.body == expected_json_response
 
 
 @pytest.mark.asyncio
@@ -16,32 +21,8 @@ async def test_person_not_found(make_get_request, es_from_snapshot):
 
 
 @pytest.mark.asyncio
-async def test_person_by_id(make_get_request, es_from_snapshot):
+async def test_person_by_id(make_get_request, es_from_snapshot, expected_json_response):
     some_id = "239f6e94-b317-4f10-bb0c-ef86dfe33d8a"
     response = await make_get_request(f"/person/{some_id}")
     assert response.status == 200
-    assert response.body == {'id': '239f6e94-b317-4f10-bb0c-ef86dfe33d8a',
-                             'full_name': 'George Lucas',
-                             'films': [{'id': '00a7ea86-a39d-4f6b-b790-325551aea635', 'role': 'writer'},
-                                       {'id': '07725695-eca3-4584-97b4-a63b0f41f72e', 'role': 'writer'},
-                                       {'id': '0b9b87af-910d-49cf-b327-874519ecb187', 'role': 'writer'},
-                                       {'id': '16e85475-63d1-4707-bf8e-f86cd3c92502', 'role': 'writer'},
-                                       {'id': '19f02d63-1a52-4da5-9cde-8533c03864b4', 'role': 'writer'},
-                                       {'id': '23754811-0371-4113-bae0-92148a3a7205', 'role': 'writer'},
-                                       {'id': '26489631-e1e2-44ca-a380-f7b5607f946a', 'role': 'writer'},
-                                       {'id': '30757fe5-c5b2-49e4-ba21-305f3be45575', 'role': 'writer'},
-                                       {'id': '322c645e-7ad0-49da-9412-3c5e71bab348', 'role': 'writer'},
-                                       {'id': '38fde497-adea-4668-b1ec-6daf0ddd0eec', 'role': 'writer'},
-                                       {'id': '23754811-0371-4113-bae0-92148a3a7205', 'role': 'director'},
-                                       {'id': '26489631-e1e2-44ca-a380-f7b5607f946a', 'role': 'director'},
-                                       {'id': '322c645e-7ad0-49da-9412-3c5e71bab348', 'role': 'director'},
-                                       {'id': '3fdcd34b-7eb1-42ec-8480-abb660c165bc', 'role': 'director'},
-                                       {'id': '6f48de57-fe7d-46d6-a09f-909d8fd54fa6', 'role': 'director'},
-                                       {'id': '38dfc86f-330d-44fb-a824-a2386ec579e6', 'role': 'actor'},
-                                       {'id': '47783b76-832d-4221-829b-aafd8b646d97', 'role': 'actor'},
-                                       {'id': '5435a2d2-4ada-4756-ac98-3a9f1edc63d5', 'role': 'actor'},
-                                       {'id': 'd749e4a3-678c-41ab-95e9-2960446f6616', 'role': 'actor'},
-                                       {'id': 'd7d15cb7-dd8f-414d-acca-782c7c233171', 'role': 'actor'},
-                                       {'id': 'e00117ef-913e-41f0-9d52-4ab40556a240', 'role': 'actor'}
-                                       ]
-                             }
+    assert response.body == expected_json_response

--- a/tests/functional/src/test_person.py
+++ b/tests/functional/src/test_person.py
@@ -10,13 +10,12 @@ async def test_search_person(make_get_request, es_from_snapshot):
 @pytest.mark.asyncio
 async def test_person_not_found(make_get_request, es_from_snapshot):
     some_id = "this-is-not-even-an-uuid"
-    response = await make_get_request(f"/person/{some_id}", params={})
+    response = await make_get_request(f"/person/{some_id}")
     assert response.status == 404
 
 
 @pytest.mark.asyncio
 async def test_person_by_id(make_get_request, es_from_snapshot):
     some_id = "239f6e94-b317-4f10-bb0c-ef86dfe33d8a"
-    response = await make_get_request(f"/person/{some_id}", params={})
-    print(response.body)
+    response = await make_get_request(f"/person/{some_id}")
     assert response.status == 200

--- a/tests/functional/src/test_person.py
+++ b/tests/functional/src/test_person.py
@@ -24,6 +24,5 @@ async def test_person_by_id(make_get_request, es_from_snapshot, expected_json_re
 async def test_person_films_by_id(make_get_request, es_from_snapshot, expected_json_response):
     some_id = "239f6e94-b317-4f10-bb0c-ef86dfe33d8a"
     response = await make_get_request(f"/person/{some_id}/film")
-    print(response.body)
     assert response.status == 200
     assert response.body == expected_json_response

--- a/tests/functional/src/test_person.py
+++ b/tests/functional/src/test_person.py
@@ -12,6 +12,7 @@ async def test_person_not_found(make_get_request, es_from_snapshot):
     some_id = "this-is-not-even-an-uuid"
     response = await make_get_request(f"/person/{some_id}")
     assert response.status == 404
+    assert response.body == {"detail": "person not found"}
 
 
 @pytest.mark.asyncio
@@ -19,3 +20,28 @@ async def test_person_by_id(make_get_request, es_from_snapshot):
     some_id = "239f6e94-b317-4f10-bb0c-ef86dfe33d8a"
     response = await make_get_request(f"/person/{some_id}")
     assert response.status == 200
+    assert response.body == {'id': '239f6e94-b317-4f10-bb0c-ef86dfe33d8a',
+                             'full_name': 'George Lucas',
+                             'films': [{'id': '00a7ea86-a39d-4f6b-b790-325551aea635', 'role': 'writer'},
+                                       {'id': '07725695-eca3-4584-97b4-a63b0f41f72e', 'role': 'writer'},
+                                       {'id': '0b9b87af-910d-49cf-b327-874519ecb187', 'role': 'writer'},
+                                       {'id': '16e85475-63d1-4707-bf8e-f86cd3c92502', 'role': 'writer'},
+                                       {'id': '19f02d63-1a52-4da5-9cde-8533c03864b4', 'role': 'writer'},
+                                       {'id': '23754811-0371-4113-bae0-92148a3a7205', 'role': 'writer'},
+                                       {'id': '26489631-e1e2-44ca-a380-f7b5607f946a', 'role': 'writer'},
+                                       {'id': '30757fe5-c5b2-49e4-ba21-305f3be45575', 'role': 'writer'},
+                                       {'id': '322c645e-7ad0-49da-9412-3c5e71bab348', 'role': 'writer'},
+                                       {'id': '38fde497-adea-4668-b1ec-6daf0ddd0eec', 'role': 'writer'},
+                                       {'id': '23754811-0371-4113-bae0-92148a3a7205', 'role': 'director'},
+                                       {'id': '26489631-e1e2-44ca-a380-f7b5607f946a', 'role': 'director'},
+                                       {'id': '322c645e-7ad0-49da-9412-3c5e71bab348', 'role': 'director'},
+                                       {'id': '3fdcd34b-7eb1-42ec-8480-abb660c165bc', 'role': 'director'},
+                                       {'id': '6f48de57-fe7d-46d6-a09f-909d8fd54fa6', 'role': 'director'},
+                                       {'id': '38dfc86f-330d-44fb-a824-a2386ec579e6', 'role': 'actor'},
+                                       {'id': '47783b76-832d-4221-829b-aafd8b646d97', 'role': 'actor'},
+                                       {'id': '5435a2d2-4ada-4756-ac98-3a9f1edc63d5', 'role': 'actor'},
+                                       {'id': 'd749e4a3-678c-41ab-95e9-2960446f6616', 'role': 'actor'},
+                                       {'id': 'd7d15cb7-dd8f-414d-acca-782c7c233171', 'role': 'actor'},
+                                       {'id': 'e00117ef-913e-41f0-9d52-4ab40556a240', 'role': 'actor'}
+                                       ]
+                             }

--- a/tests/functional/src/test_person.py
+++ b/tests/functional/src/test_person.py
@@ -13,14 +13,6 @@ async def test_search_person(make_get_request, es_from_snapshot, expected_json_r
 
 
 @pytest.mark.asyncio
-async def test_person_not_found(make_get_request, es_from_snapshot):
-    some_id = "this-is-not-even-an-uuid"
-    response = await make_get_request(f"/person/{some_id}")
-    assert response.status == 404
-    assert response.body == {"detail": "person not found"}
-
-
-@pytest.mark.asyncio
 async def test_person_by_id(make_get_request, es_from_snapshot, expected_json_response):
     some_id = "239f6e94-b317-4f10-bb0c-ef86dfe33d8a"
     response = await make_get_request(f"/person/{some_id}")

--- a/tests/functional/src/test_person.py
+++ b/tests/functional/src/test_person.py
@@ -26,3 +26,12 @@ async def test_person_by_id(make_get_request, es_from_snapshot, expected_json_re
     response = await make_get_request(f"/person/{some_id}")
     assert response.status == 200
     assert response.body == expected_json_response
+
+
+@pytest.mark.asyncio
+async def test_person_films_by_id(make_get_request, es_from_snapshot, expected_json_response):
+    some_id = "239f6e94-b317-4f10-bb0c-ef86dfe33d8a"
+    response = await make_get_request(f"/person/{some_id}/film")
+    print(response.body)
+    assert response.status == 200
+    assert response.body == expected_json_response

--- a/tests/functional/src/test_person.py
+++ b/tests/functional/src/test_person.py
@@ -4,4 +4,11 @@ import pytest
 @pytest.mark.asyncio
 async def test_search_person(make_get_request):
     response = await make_get_request("/person/search/", params={"query": "Lucas"})
-    assert response.status in (200, 404)
+    assert response.status == 200
+
+
+@pytest.mark.asyncio
+async def test_person_not_found(make_get_request):
+    some_id = "this-is-not-even-an-uuid"
+    response = await make_get_request(f"/person/{some_id}", params={})
+    assert response.status == 404

--- a/tests/functional/src/test_person.py
+++ b/tests/functional/src/test_person.py
@@ -2,20 +2,20 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_search_person(make_get_request):
+async def test_search_person(make_get_request, es_from_snapshot):
     response = await make_get_request("/person/search/", params={"query": "Lucas"})
     assert response.status == 200
 
 
 @pytest.mark.asyncio
-async def test_person_not_found(make_get_request):
+async def test_person_not_found(make_get_request, es_from_snapshot):
     some_id = "this-is-not-even-an-uuid"
     response = await make_get_request(f"/person/{some_id}", params={})
     assert response.status == 404
 
 
 @pytest.mark.asyncio
-async def test_person_by_id(make_get_request):
+async def test_person_by_id(make_get_request, es_from_snapshot):
     some_id = "239f6e94-b317-4f10-bb0c-ef86dfe33d8a"
     response = await make_get_request(f"/person/{some_id}", params={})
     print(response.body)

--- a/tests/functional/src/test_person.py
+++ b/tests/functional/src/test_person.py
@@ -12,3 +12,11 @@ async def test_person_not_found(make_get_request):
     some_id = "this-is-not-even-an-uuid"
     response = await make_get_request(f"/person/{some_id}", params={})
     assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_person_by_id(make_get_request):
+    some_id = "239f6e94-b317-4f10-bb0c-ef86dfe33d8a"
+    response = await make_get_request(f"/person/{some_id}", params={})
+    print(response.body)
+    assert response.status == 200

--- a/tests/functional/testdata/expected_response/test_person_by_id.json
+++ b/tests/functional/testdata/expected_response/test_person_by_id.json
@@ -1,0 +1,90 @@
+{
+  "id": "239f6e94-b317-4f10-bb0c-ef86dfe33d8a",
+  "full_name": "George Lucas",
+  "films": [
+    {
+      "id": "00a7ea86-a39d-4f6b-b790-325551aea635",
+      "role": "writer"
+    },
+    {
+      "id": "07725695-eca3-4584-97b4-a63b0f41f72e",
+      "role": "writer"
+    },
+    {
+      "id": "0b9b87af-910d-49cf-b327-874519ecb187",
+      "role": "writer"
+    },
+    {
+      "id": "16e85475-63d1-4707-bf8e-f86cd3c92502",
+      "role": "writer"
+    },
+    {
+      "id": "19f02d63-1a52-4da5-9cde-8533c03864b4",
+      "role": "writer"
+    },
+    {
+      "id": "23754811-0371-4113-bae0-92148a3a7205",
+      "role": "writer"
+    },
+    {
+      "id": "26489631-e1e2-44ca-a380-f7b5607f946a",
+      "role": "writer"
+    },
+    {
+      "id": "30757fe5-c5b2-49e4-ba21-305f3be45575",
+      "role": "writer"
+    },
+    {
+      "id": "322c645e-7ad0-49da-9412-3c5e71bab348",
+      "role": "writer"
+    },
+    {
+      "id": "38fde497-adea-4668-b1ec-6daf0ddd0eec",
+      "role": "writer"
+    },
+    {
+      "id": "23754811-0371-4113-bae0-92148a3a7205",
+      "role": "director"
+    },
+    {
+      "id": "26489631-e1e2-44ca-a380-f7b5607f946a",
+      "role": "director"
+    },
+    {
+      "id": "322c645e-7ad0-49da-9412-3c5e71bab348",
+      "role": "director"
+    },
+    {
+      "id": "3fdcd34b-7eb1-42ec-8480-abb660c165bc",
+      "role": "director"
+    },
+    {
+      "id": "6f48de57-fe7d-46d6-a09f-909d8fd54fa6",
+      "role": "director"
+    },
+    {
+      "id": "38dfc86f-330d-44fb-a824-a2386ec579e6",
+      "role": "actor"
+    },
+    {
+      "id": "47783b76-832d-4221-829b-aafd8b646d97",
+      "role": "actor"
+    },
+    {
+      "id": "5435a2d2-4ada-4756-ac98-3a9f1edc63d5",
+      "role": "actor"
+    },
+    {
+      "id": "d749e4a3-678c-41ab-95e9-2960446f6616",
+      "role": "actor"
+    },
+    {
+      "id": "d7d15cb7-dd8f-414d-acca-782c7c233171",
+      "role": "actor"
+    },
+    {
+      "id": "e00117ef-913e-41f0-9d52-4ab40556a240",
+      "role": "actor"
+    }
+  ]
+}

--- a/tests/functional/testdata/expected_response/test_person_films_by_id.json
+++ b/tests/functional/testdata/expected_response/test_person_films_by_id.json
@@ -3,15 +3,13 @@
       "id":"23754811-0371-4113-bae0-92148a3a7205",
       "title":"Star Wars: Episode IV: A New Hope - Deleted Scenes",
       "imdb_rating":8.4,
-      "description":"Deleted scenes from Star Wars: Ep
-isode IV - A New Hope (1977)."
+      "description":"Deleted scenes from Star Wars: Episode IV - A New Hope (1977)."
    },
    {
       "id":"26489631-e1e2-44ca-a380-f7b5607f946a",
       "title":"Star Wars: Episode IV - A New Hope",
       "imdb_rating":8.6,
-      "description":"The Imperial Forces, under orders fr
-om cruel Darth Vader, hold Princess Leia hostage in their efforts to quell the rebellion against the Galactic Empire. Luke Skywalker and Han Solo, captain of the Millennium Falcon, work together with
+      "description":"The Imperial Forces, under orders from cruel Darth Vader, hold Princess Leia hostage in their efforts to quell the rebellion against the Galactic Empire. Luke Skywalker and Han Solo, captain of the Millennium Falcon, work together with
  the companionable droid duo R2-D2 and C-3PO to rescue the beautiful princess, help the Rebel Alliance and restore freedom and justice to the Galaxy."
    },
    {
@@ -19,15 +17,14 @@ om cruel Darth Vader, hold Princess Leia hostage in their efforts to quell the r
       "title":"Star Wars: Episode I - The Phantom Menace",
       "imdb_rating":6.5,
       "description":"The evil Trade Federation, led by Nute Gunray is planning to take over the peaceful world of Naboo. Jedi Kni
-ghts Qui-Gon Jinn and Obi-Wan Kenobi are sent to confront the leaders. But not everything goes to plan. The two Jedi escape, and along with their new Gungan friend, Jar Jar Binks head to Naboo to war
+      ghts Qui-Gon Jinn and Obi-Wan Kenobi are sent to confront the leaders. But not everything goes to plan. The two Jedi escape, and along with their new Gungan friend, Jar Jar Binks head to Naboo to war
 n Queen Amidala, but droids have already started to capture Naboo and the Queen is not safe there. Eventually, they land on Tatooine, where they become friends with a young boy known as Anakin Skywal
 ker. Qui-Gon is curious about the boy, and sees a bright future for him. The group must now find a way of getting to Coruscant and to finally solve this trade dispute, but there is someone else hidin
 g in the shadows. Are the Sith really extinct? Is the Queen really who she says she is? And what's so special about this young boy?"
    },
    {
       "id":"3fdcd34b-7eb1-42ec-8480-abb660c165bc",
-      "title":"Star Wa
-rs: Episode II - Attack of the Clones",
+      "title":"Star Wars: Episode II - Attack of the Clones",
       "imdb_rating":6.5,
       "description":"Ten years after the invasion of Naboo, the Galactic Republic is facing a Separatist movement and the former queen and now S
 enator Padmé Amidala travels to Coruscant to vote on a project to create an army to help the Jedi to protect the Republic. Upon arrival, she escapes from an attempt to kill her, and Obi-Wan Kenobi an
@@ -64,8 +61,7 @@ ed is Star Wars mania, how fans loved the movie, collected the merchandise and d
 ption":"Filmmakers, critics and even politicians discuss the social impact of the \"Star Wars\" films and the franchise\\'s reliance in mythology and history."
    },
    {
-      "id":"5435a2d2-4ada-4756-ac98-3a9f1ed
-c63d5",
+      "id":"5435a2d2-4ada-4756-ac98-3a9f1edc63d5",
       "title":"Empire of Dreams: The Story of the 'Star Wars' Trilogy",
       "imdb_rating":8.3,
       "description":"This documentary chronicles the making of the original Star Wars trilogy from start to f
@@ -80,8 +76,7 @@ iews with plenty of cast & crew members."
       "description":""
    },
    {
-      "id":"d7d15cb7-dd8f-414d-
-acca-782c7c233171",
+      "id":"d7d15cb7-dd8f-414d-acca-782c7c233171",
       "title":"From 'Star Wars' to 'Jedi': The Making of a Saga",
       "imdb_rating":7.7,
       "description":"Ever wonder how they ever made Star Wars, Empire Strikes Back, and Return of the J

--- a/tests/functional/testdata/expected_response/test_person_films_by_id.json
+++ b/tests/functional/testdata/expected_response/test_person_films_by_id.json
@@ -1,0 +1,91 @@
+[
+   {
+      "id":"23754811-0371-4113-bae0-92148a3a7205",
+      "title":"Star Wars: Episode IV: A New Hope - Deleted Scenes",
+      "imdb_rating":8.4,
+      "description":"Deleted scenes from Star Wars: Ep
+isode IV - A New Hope (1977)."
+   },
+   {
+      "id":"26489631-e1e2-44ca-a380-f7b5607f946a",
+      "title":"Star Wars: Episode IV - A New Hope",
+      "imdb_rating":8.6,
+      "description":"The Imperial Forces, under orders fr
+om cruel Darth Vader, hold Princess Leia hostage in their efforts to quell the rebellion against the Galactic Empire. Luke Skywalker and Han Solo, captain of the Millennium Falcon, work together with
+ the companionable droid duo R2-D2 and C-3PO to rescue the beautiful princess, help the Rebel Alliance and restore freedom and justice to the Galaxy."
+   },
+   {
+      "id":"322c645e-7ad0-49da-9412-3c5e71bab348",
+      "title":"Star Wars: Episode I - The Phantom Menace",
+      "imdb_rating":6.5,
+      "description":"The evil Trade Federation, led by Nute Gunray is planning to take over the peaceful world of Naboo. Jedi Kni
+ghts Qui-Gon Jinn and Obi-Wan Kenobi are sent to confront the leaders. But not everything goes to plan. The two Jedi escape, and along with their new Gungan friend, Jar Jar Binks head to Naboo to war
+n Queen Amidala, but droids have already started to capture Naboo and the Queen is not safe there. Eventually, they land on Tatooine, where they become friends with a young boy known as Anakin Skywal
+ker. Qui-Gon is curious about the boy, and sees a bright future for him. The group must now find a way of getting to Coruscant and to finally solve this trade dispute, but there is someone else hidin
+g in the shadows. Are the Sith really extinct? Is the Queen really who she says she is? And what's so special about this young boy?"
+   },
+   {
+      "id":"3fdcd34b-7eb1-42ec-8480-abb660c165bc",
+      "title":"Star Wa
+rs: Episode II - Attack of the Clones",
+      "imdb_rating":6.5,
+      "description":"Ten years after the invasion of Naboo, the Galactic Republic is facing a Separatist movement and the former queen and now S
+enator Padmé Amidala travels to Coruscant to vote on a project to create an army to help the Jedi to protect the Republic. Upon arrival, she escapes from an attempt to kill her, and Obi-Wan Kenobi an
+d his Padawan Anakin Skywalker are assigned to protect her. They chase the shape-shifter Zam Wessell but she is killed by a poisoned dart before revealing who hired her. The Jedi Council assigns Obi-
+Wan Kenobi to discover who has tried to kill Amidala and Anakin to protect her in Naboo. Obi-Wan discovers that the dart is from the planet Kamino, and he heads to the remote planet. He finds an army
+ of clones that has been under production for years for the Republic and that the bounty hunter Jango Fett was the matrix for the clones. Meanwhile Anakin and Amidala fall in love with each other, an
+d he has nightmarish visions of his mother. They travel to his home planet, Tatooine, to see his mother, and he discovers that she has been abducted by Tusken Raiders. Anakin finds his mother dying,
+and he kills all the Tusken tribe, including the women and children. Obi-Wan follows Jango Fett to the planet Geonosis where he discovers who is behind the Separatist movement. He transmits his disco
+veries to Anakin since he cannot reach the Jedi Council. Who is the leader of the Separatist movement? Will Anakin receive Obi-Wan's message? And will the secret love between Anakin and Amidala succe
+ed?"
+   },
+   {
+      "id":"6f48de57-fe7d-46d6-a09f-909d8fd54fa6",
+      "title":"Star Wars: Episode III - Revenge of the Sith",
+      "imdb_rating":7.5,
+      "description":"Near the end of the Clone Wars, Darth Sidious has re
+vealed himself and is ready to execute the last part of his plan to rule the galaxy. Sidious is ready for his new apprentice, Darth Vader, to step into action and kill the remaining Jedi. Vader, howe
+ver, struggles to choose the dark side and save his wife or remain loyal to the Jedi order."
+   },
+   {
+      "id":"38dfc86f-330d-44fb-a824-a2386ec579e6",
+      "title":"The Making of 'Star Wars'",
+      "imdb_rating":7.5,
+      "description":"Ever wonder how they ever managed to make a movie like Star Wars? Well, bickering droid duo C-3PO and R2-D2 host this tour of the mind of creator George Lucas and what inspired him t
+o make the movie. Even interviewed are the cast and crew, even features scenes of when C-3PO, R2-D2, and Darth Vader planted their footprints (or in R2's case, tread-prints) into cement. Also discuss
+ed is Star Wars mania, how fans loved the movie, collected the merchandise and danced the disco music. Also shown are behind-the-scenes looks at the movie, as well as how difficult each effect was in
+ doing since they didn't have the convenience of computer animation back then."
+   },
+   {
+      "id":"47783b76-832d-4221-829b-aafd8b646d97",
+      "title":"Star Wars: The Legacy Revealed",
+      "imdb_rating":7.8,
+      "descri
+ption":"Filmmakers, critics and even politicians discuss the social impact of the \"Star Wars\" films and the franchise\\'s reliance in mythology and history."
+   },
+   {
+      "id":"5435a2d2-4ada-4756-ac98-3a9f1ed
+c63d5",
+      "title":"Empire of Dreams: The Story of the 'Star Wars' Trilogy",
+      "imdb_rating":8.3,
+      "description":"This documentary chronicles the making of the original Star Wars trilogy from start to f
+inish. We get some background on George Lucas' start in the business and then continue with the making of Star Wars (1977), Star Wars: Episode V - The Empire Strikes Back (1980) and Star Wars: Episod
+e VI - Return of the Jedi (1983). The visual/special effects and financial problems are explained as well as casting, editing, scoring and releasing the films with tons of archival footage and interv
+iews with plenty of cast & crew members."
+   },
+   {
+      "id":"d749e4a3-678c-41ab-95e9-2960446f6616",
+      "title":"The Mythology of 'Star Wars'",
+      "imdb_rating":6.8,
+      "description":""
+   },
+   {
+      "id":"d7d15cb7-dd8f-414d-
+acca-782c7c233171",
+      "title":"From 'Star Wars' to 'Jedi': The Making of a Saga",
+      "imdb_rating":7.7,
+      "description":"Ever wonder how they ever made Star Wars, Empire Strikes Back, and Return of the J
+edi? Well this documentary explains it all as we're taken on a behind-the-scenes tour of the making of the Star Wars saga. It shows how the puppets are made and worked, and creator George Lucas talks
+ about what influenced him to do it, and everything. Narrated by Luke Skywalker himself, Mark Hamill."
+   }
+]

--- a/tests/functional/testdata/expected_response/test_search_person.json
+++ b/tests/functional/testdata/expected_response/test_search_person.json
@@ -1,0 +1,130 @@
+[
+  {
+    "id": "239f6e94-b317-4f10-bb0c-ef86dfe33d8a",
+    "full_name": "George Lucas",
+    "films": [
+      {
+        "id": "00a7ea86-a39d-4f6b-b790-325551aea635",
+        "role": "writer"
+      },
+      {
+        "id": "07725695-eca3-4584-97b4-a63b0f41f72e",
+        "role": "writer"
+      },
+      {
+        "id": "0b9b87af-910d-49cf-b327-874519ecb187",
+        "role": "writer"
+      },
+      {
+        "id": "16e85475-63d1-4707-bf8e-f86cd3c92502",
+        "role": "writer"
+      },
+      {
+        "id": "19f02d63-1a52-4da5-9cde-8533c03864b4",
+        "role": "writer"
+      },
+      {
+        "id": "23754811-0371-4113-bae0-92148a3a7205",
+        "role": "writer"
+      },
+      {
+        "id": "26489631-e1e2-44ca-a380-f7b5607f946a",
+        "role": "writer"
+      },
+      {
+        "id": "30757fe5-c5b2-49e4-ba21-305f3be45575",
+        "role": "writer"
+      },
+      {
+        "id": "322c645e-7ad0-49da-9412-3c5e71bab348",
+        "role": "writer"
+      },
+      {
+        "id": "38fde497-adea-4668-b1ec-6daf0ddd0eec",
+        "role": "writer"
+      },
+      {
+        "id": "23754811-0371-4113-bae0-92148a3a7205",
+        "role": "director"
+      },
+      {
+        "id": "26489631-e1e2-44ca-a380-f7b5607f946a",
+        "role": "director"
+      },
+      {
+        "id": "322c645e-7ad0-49da-9412-3c5e71bab348",
+        "role": "director"
+      },
+      {
+        "id": "3fdcd34b-7eb1-42ec-8480-abb660c165bc",
+        "role": "director"
+      },
+      {
+        "id": "6f48de57-fe7d-46d6-a09f-909d8fd54fa6",
+        "role": "director"
+      },
+      {
+        "id": "38dfc86f-330d-44fb-a824-a2386ec579e6",
+        "role": "actor"
+      },
+      {
+        "id": "47783b76-832d-4221-829b-aafd8b646d97",
+        "role": "actor"
+      },
+      {
+        "id": "5435a2d2-4ada-4756-ac98-3a9f1edc63d5",
+        "role": "actor"
+      },
+      {
+        "id": "d749e4a3-678c-41ab-95e9-2960446f6616",
+        "role": "actor"
+      },
+      {
+        "id": "d7d15cb7-dd8f-414d-acca-782c7c233171",
+        "role": "actor"
+      },
+      {
+        "id": "e00117ef-913e-41f0-9d52-4ab40556a240",
+        "role": "actor"
+      }
+    ]
+  },
+  {
+    "id": "0afccd18-00a9-4e9e-9f17-11f2f2be0c5d",
+    "full_name": "Stu Lucas",
+    "films": [
+      {
+        "id": "6615dbdf-2dc8-4cd1-a826-fc127b95e5c3",
+        "role": "actor"
+      }
+    ]
+  },
+  {
+    "id": "e0056809-17d3-403e-9bb1-eb010dca910d",
+    "full_name": "Luca Boni",
+    "films": [
+      {
+        "id": "a519e1a4-48c3-4e13-963e-071df73ae1ff",
+        "role": "writer"
+      },
+      {
+        "id": "a519e1a4-48c3-4e13-963e-071df73ae1ff",
+        "role": "director"
+      }
+    ]
+  },
+  {
+    "id": "0ded4eab-53aa-4430-906e-df53fb788c7b",
+    "full_name": "Mat Lucas",
+    "films": [
+      {
+        "id": "088e696e-a751-4e06-baf0-4ca74350f096",
+        "role": "actor"
+      },
+      {
+        "id": "a9f7f350-d710-41cb-8cc4-9b980dea14e2",
+        "role": "actor"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Название ветки не полностью соответствует вносимым изменениям.

Изменения в порядке важности:

1. Добавлена инфраструктура для сравнения ответов API с ответами, записанными в файлах. Инструкция к применению:
Есть фикстура `expected_json_response`. Фикстура достаёт имя тестовой функции, в которой она запрашивается. По имени тестовой функции в `tests/functional/testdata/expected_response/` находится `json` файл с ожидаемым от API ответом. Из файла `json` парсится в словарь и возвращается. В тестовой функции (см. `test_person_by_id`) этот словарь достаточно сравнить с `response.body` от API, чтобы убедиться, что он правильный.
2. Добавлено два теста для `api/v1/persons`
3. Добавлен обобщённый параметризированный `test_404_general`. Он применим ко всем ручкам API, которые должны возвращать 404. Расширяйте список параметров по желанию.
4. `make_get_request` имеет значение по умолчанию для аргумента `params`, чтобы не прокидывать пустой словарь для ручек без параметров.
5. Убран `nginx` из `docker-compose.tests.yaml`
6. В docker-compose.tests.yaml контейнер с pytest запускается с дополнительным параметром `-rP`, чтобы получать вывод `print()`. Упрощает поиск проблем)